### PR TITLE
Switched tiers from free to basic

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,11 +44,11 @@
     "formation": {
       "web": {
         "quantity": 1,
-        "size": "free"
+        "size": "basic"
       },
       "worker": {
         "quantity": 1,
-        "size": "free"
+        "size": "basic"
       }
     },
     "addons": [


### PR DESCRIPTION
Free tiers have been removed from Heroku, so automatic deploy was failing. This defaults them to basic.